### PR TITLE
Skip some chunk errors

### DIFF
--- a/src/unzip.js
+++ b/src/unzip.js
@@ -18,7 +18,13 @@ async function pakoUnzip(inputData) {
     inflator = new Inflate()
     strm = inflator.strm
     inflator.push(remainingInput, Z_SYNC_FLUSH)
-    if (inflator.err) throw new Error(inflator.msg)
+    if (inflator.err) {
+      if (chunks.length) {
+        break
+      } else {
+        throw new Error(inflator.msg)
+      }
+    }
 
     pos += strm.next_in
     chunks[i] = Buffer.from(inflator.result)

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -19,7 +19,11 @@ async function pakoUnzip(inputData) {
     strm = inflator.strm
     inflator.push(remainingInput, Z_SYNC_FLUSH)
     if (inflator.err) {
-      if (chunks.length) {
+      if (
+        chunks.length &&
+        (inflator.err === -3 /* Z_DATA_ERROR */ ||
+          inflator.err === -5) /* Z_BUF_ERROR */
+      ) {
         break
       } else {
         throw new Error(inflator.msg)


### PR DESCRIPTION
Due to https://github.com/cmdcolin/bam-js/issues/4 I found that maybe this code from JBrowse's BGZBlob could be ported over to this code https://github.com/GMOD/jbrowse/blob/master/src/JBrowse/Model/BGZip/BGZBlob.js#L97-L109


I took this code to basically mean that if we have any chunks decoded then we should allow the decoding to halt instead of throwing an error in this case

Note that the original BGZBlob inspects the error type for Z_BUF_ERROR (-5). I looked at the inflator error that I was getting and it was I think Z_DATA_ERROR (-3). Therefore I made this code check for both

The problematic chunk in the volvox-sorted.bam is fairly specific at ctgA:32749-32799 but I found the bam-js code and the current JBrowse code decoded this chunk the same so I figured it must come back to the decoding :)
