### PR TITLE
Switch to es6-promisify

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   ],
   "dependencies": {
     "binary-parser": "^1.3.2",
+    "es6-promisify": "^6.0.1",
     "fs-extra": "^7.0.0",
     "long": "^4.0.0",
-    "pako": "^1.0.6",
-    "util.promisify": "^1.0.0"
+    "pako": "^1.0.6"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -1,5 +1,6 @@
 const zlib = require('zlib')
-const gunzip = require('util.promisify')(zlib.gunzip)
+const {promisify} = require('es6-promisify')
+const gunzip = promisify(zlib.gunzip)
 
 const { Z_SYNC_FLUSH, Inflate } = require('pako')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1989,6 +1989,11 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es6-promisify@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
+  integrity sha512-J3ZkwbEnnO+fGAKrjVpeUAnZshAdfZvbhQpqfIH9kSAspReRC4nJnu8ewm55b4y9ElyeuhCTzJD0XiH8Tsbhlw==
+
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
This switches to use es6-promisify instead of util.promisify since it can invoke Object.defineProperty length which seems un-babel-ifiable