### PR TITLE
Process dataPosition minv/maxv in unzipChunk to fix tabix bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-# bgzf-filehandle
 
 [![NPM version](https://img.shields.io/npm/v/@gmod/bgzf-filehandle.svg?style=flat-square)](https://npmjs.org/package/@gmod/bgzf-filehandle)
 [![Build Status](https://img.shields.io/travis/GMOD/bgzf-filehandle/master.svg?style=flat-square)](https://travis-ci.org/GMOD/bgzf-filehandle) [![Greenkeeper badge](https://badges.greenkeeper.io/GMOD/bgzf-filehandle.svg)](https://greenkeeper.io/) 
@@ -39,8 +38,14 @@ const unzippedBuffer = await unzip(chunkDataBuffer)
 // unzipChunk takes a buffer and returns a decompressed buffer plus the offsets
 // of the block boundaries in the bgzip file in compressed (cpositions) and
 // decompressed (dpositions) coordinates
+// you can ignore dpositions/cpositions if your code doesn't care about stable feature IDs
 const {buffer, dpositions, cpositions} = await unzipChunk(chunkDataBuffer)
 
+// similar to the above unzipChunk but takes extra chunk argument and trims
+// off (0,chunk.minv.dataPosition) and (chunk.maxv.dataPosition)
+// used especially for generating stable feature IDs across chunk boundaries
+// normal unzip or unzipChunk can be used if this is not important
+const {buffer, dpositions, cpositions} = await unzipChunkSlice(chunkDataBuffer, chunk)
 ```
 
 ## Academic Use

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
 const BgzfFilehandle = require('./bgzFilehandle')
-const { unzip, unzipChunk } = require('./unzip')
+const { unzip, unzipChunk, unzipChunkSlice } = require('./unzip')
 
-module.exports = { BgzfFilehandle, unzip, unzipChunk }
+module.exports = { BgzfFilehandle, unzip, unzipChunk, unzipChunkSlice }

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -129,6 +129,7 @@ function nodeUnzip(input) {
 module.exports = {
   unzip: typeof __webpack_require__ === 'function' ? pakoUnzip : nodeUnzip, // eslint-disable-line
   unzipChunk,
+  unzipChunkSlice,
   nodeUnzip,
   pakoUnzip,
 }

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -34,7 +34,39 @@ async function pakoUnzip(inputData) {
 // similar to pakounzip, except it does extra counting
 // to return the positions of compressed and decompressed
 // data offsets
-async function unzipChunk(inputData, chunk) {
+async function unzipChunk(inputData) {
+  let strm
+  let cpos = 0
+  let dpos = 0
+  const blocks = []
+  const cpositions = []
+  const dpositions = []
+  do {
+    const remainingInput = inputData.slice(cpos)
+    const inflator = new Inflate()
+    // @ts-ignore
+    ;({ strm } = inflator)
+    // @ts-ignore
+    inflator.push(remainingInput, Z_SYNC_FLUSH)
+    if (inflator.err) throw new Error(inflator.msg)
+
+    // @ts-ignore
+    const buffer = Buffer.from(inflator.result)
+    blocks.push(buffer)
+
+    cpositions.push(cpos)
+    dpositions.push(dpos)
+
+    cpos += strm.next_in
+    dpos += buffer.length
+  } while (strm.avail_in)
+
+  const buffer = Buffer.concat(blocks)
+  return { buffer, cpositions, dpositions }
+}
+
+// similar to unzipChunk above but slices (0,minv.dataPosition) and (maxv.dataPosition,end) off
+async function unzipChunkSlice(inputData, chunk) {
   let strm
   let cpos = 0
   let dpos = 0

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -54,13 +54,22 @@ async function unzipChunk(inputData, chunk) {
     const buffer = Buffer.from(inflator.result)
     decompressedBlocks.push(buffer)
 
+    const origCpos = cpos
+
     if (decompressedBlocks.length === 1 && chunk.minv.dataPosition) {
       // this is the first chunk, trim it
       decompressedBlocks[0] = decompressedBlocks[0].slice(
         chunk.minv.dataPosition,
       )
+      dpos -= chunk.minv.dataPosition
+      console.log('here', chunk.minv.dataPosition)
     }
-    if (chunk.minv.blockPosition + cpos >= chunk.maxv.blockPosition) {
+
+    cpositions.push(cpos)
+    dpositions.push(dpos)
+    cpos += strm.next_in
+    dpos += buffer.length
+    if (chunk.minv.blockPosition + origCpos >= chunk.maxv.blockPosition) {
       // this is the last chunk, trim it and stop decompressing
       // note if it is the same block is minv it subtracts that already
       // trimmed part of the slice length
@@ -73,14 +82,9 @@ async function unzipChunk(inputData, chunk) {
           ? chunk.maxv.dataPosition - chunk.minv.dataPosition + 1
           : chunk.maxv.dataPosition + 1,
       )
+
       break
     }
-
-    cpositions.push(cpos)
-    dpositions.push(dpos)
-
-    cpos += strm.next_in
-    dpos += buffer.length
   } while (strm.avail_in)
 
   const buffer = Buffer.concat(decompressedBlocks)

--- a/src/unzip.js
+++ b/src/unzip.js
@@ -54,21 +54,17 @@ async function unzipChunk(inputData, chunk) {
     const buffer = Buffer.from(inflator.result)
     decompressedBlocks.push(buffer)
 
-    const origCpos = cpos
-
     if (decompressedBlocks.length === 1 && chunk.minv.dataPosition) {
       // this is the first chunk, trim it
       decompressedBlocks[0] = decompressedBlocks[0].slice(
         chunk.minv.dataPosition,
       )
-      dpos -= chunk.minv.dataPosition
-      console.log('here', chunk.minv.dataPosition)
     }
-
-    cpositions.push(cpos)
-    dpositions.push(dpos)
+    const origCpos = cpos
     cpos += strm.next_in
     dpos += buffer.length
+    cpositions.push(cpos)
+    dpositions.push(dpos)
     if (chunk.minv.blockPosition + origCpos >= chunk.maxv.blockPosition) {
       // this is the last chunk, trim it and stop decompressing
       // note if it is the same block is minv it subtracts that already

--- a/test/__snapshots__/unzip.test.js.snap
+++ b/test/__snapshots__/unzip.test.js.snap
@@ -23,3 +23,41 @@ Array [
   84033,
 ]
 `;
+
+exports[`unzipChunkSlice can unzip bgzip-1.txt.gz 1`] = `
+Array [
+  22579,
+]
+`;
+
+exports[`unzipChunkSlice can unzip bgzip-1.txt.gz 2`] = `
+Array [
+  4682,
+]
+`;
+
+exports[`unzipChunkSlice can unzip bgzip-1.txt.gz positive maxv.blockPosition 1`] = `
+Array [
+  22579,
+  87646,
+]
+`;
+
+exports[`unzipChunkSlice can unzip bgzip-1.txt.gz positive maxv.blockPosition 2`] = `
+Array [
+  4682,
+  24403,
+]
+`;
+
+exports[`unzipChunkSlice can unzip bgzip-1.txt.gz positive minv.dataPosition 1`] = `
+Array [
+  22579,
+]
+`;
+
+exports[`unzipChunkSlice can unzip bgzip-1.txt.gz positive minv.dataPosition 2`] = `
+Array [
+  4682,
+]
+`;

--- a/test/unzip.test.js
+++ b/test/unzip.test.js
@@ -12,11 +12,11 @@ describe('unzip', () => {
   })
 })
 
-// describe('unzip', () => {
-//   it('can unzip bgzip-1.txt.gz', async () => {
-//     const testData = fs.readFileSync(require.resolve('./data/paired.bam'))
-//     const { dpositions, cpositions } = await unzipChunk(testData)
-//     expect(dpositions).toMatchSnapshot()
-//     expect(cpositions).toMatchSnapshot()
-//   })
-// })
+describe('unzip', () => {
+  it('can unzip bgzip-1.txt.gz', async () => {
+    const testData = fs.readFileSync(require.resolve('./data/paired.bam'))
+    const { dpositions, cpositions } = await unzipChunk(testData)
+    expect(dpositions).toMatchSnapshot()
+    expect(cpositions).toMatchSnapshot()
+  })
+})

--- a/test/unzip.test.js
+++ b/test/unzip.test.js
@@ -12,11 +12,11 @@ describe('unzip', () => {
   })
 })
 
-describe('unzip', () => {
-  it('can unzip bgzip-1.txt.gz', async () => {
-    const testData = fs.readFileSync(require.resolve('./data/paired.bam'))
-    const { dpositions, cpositions } = await unzipChunk(testData)
-    expect(dpositions).toMatchSnapshot()
-    expect(cpositions).toMatchSnapshot()
-  })
-})
+// describe('unzip', () => {
+//   it('can unzip bgzip-1.txt.gz', async () => {
+//     const testData = fs.readFileSync(require.resolve('./data/paired.bam'))
+//     const { dpositions, cpositions } = await unzipChunk(testData)
+//     expect(dpositions).toMatchSnapshot()
+//     expect(cpositions).toMatchSnapshot()
+//   })
+// })

--- a/test/unzip.test.js
+++ b/test/unzip.test.js
@@ -1,5 +1,10 @@
 const fs = require('fs')
-const { pakoUnzip, nodeUnzip, unzipChunk } = require('../src/unzip')
+const {
+  pakoUnzip,
+  nodeUnzip,
+  unzipChunk,
+  unzipChunkSlice,
+} = require('../src/unzip')
 
 describe('unzip', () => {
   it('can unzip bgzip-1.txt.gz', async () => {
@@ -16,6 +21,36 @@ describe('unzip', () => {
   it('can unzip bgzip-1.txt.gz', async () => {
     const testData = fs.readFileSync(require.resolve('./data/paired.bam'))
     const { dpositions, cpositions } = await unzipChunk(testData)
+    expect(dpositions).toMatchSnapshot()
+    expect(cpositions).toMatchSnapshot()
+  })
+})
+
+describe('unzipChunkSlice', () => {
+  it('can unzip bgzip-1.txt.gz', async () => {
+    const testData = fs.readFileSync(require.resolve('./data/paired.bam'))
+    const { dpositions, cpositions } = await unzipChunkSlice(testData, {
+      minv: { dataPosition: 0, blockPosition: 0 },
+      maxv: { dataPosition: 100, blockPosition: 0 },
+    })
+    expect(dpositions).toMatchSnapshot()
+    expect(cpositions).toMatchSnapshot()
+  })
+  it('can unzip bgzip-1.txt.gz positive minv.dataPosition', async () => {
+    const testData = fs.readFileSync(require.resolve('./data/paired.bam'))
+    const { dpositions, cpositions } = await unzipChunkSlice(testData, {
+      minv: { dataPosition: 50, blockPosition: 0 },
+      maxv: { dataPosition: 100, blockPosition: 0 },
+    })
+    expect(dpositions).toMatchSnapshot()
+    expect(cpositions).toMatchSnapshot()
+  })
+  it('can unzip bgzip-1.txt.gz positive maxv.blockPosition', async () => {
+    const testData = fs.readFileSync(require.resolve('./data/paired.bam'))
+    const { dpositions, cpositions } = await unzipChunkSlice(testData, {
+      minv: { dataPosition: 50, blockPosition: 0 },
+      maxv: { dataPosition: 100, blockPosition: 1 },
+    })
     expect(dpositions).toMatchSnapshot()
     expect(cpositions).toMatchSnapshot()
   })


### PR DESCRIPTION
This is a delicate PR for addressing tabix bugs recently. This modifies the expected behavior of unzipChunk that @gmod/bam uses so this will need another update before deploying, but @gmod/bam will probably want to use this new method anyways