### PR TITLE
Remove node unzip

### DIFF
--- a/src/unzip.js
+++ b/src/unzip.js
@@ -1,9 +1,4 @@
 /* eslint-disable consistent-return */
-const zlib = require('zlib')
-const { promisify } = require('es6-promisify')
-
-const gunzip = promisify(zlib.gunzip)
-
 const { Z_SYNC_FLUSH, Inflate } = require('pako')
 
 // browserify-zlib, which is the zlib shim used by default in webpacked code,
@@ -149,17 +144,9 @@ async function unzipChunkSlice(inputData, chunk) {
   }
 }
 
-// in node, just use the native unzipping with Z_SYNC_FLUSH
-function nodeUnzip(input) {
-  return gunzip(input, {
-    finishFlush: (zlib.constants || zlib).Z_SYNC_FLUSH,
-  })
-}
-
 module.exports = {
-  unzip: typeof __webpack_require__ === 'function' ? pakoUnzip : nodeUnzip, // eslint-disable-line
+  unzip: pakoUnzip, // eslint-disable-line
   unzipChunk,
   unzipChunkSlice,
-  nodeUnzip,
   pakoUnzip,
 }

--- a/test/unzip.test.js
+++ b/test/unzip.test.js
@@ -1,18 +1,10 @@
 const fs = require('fs')
-const {
-  pakoUnzip,
-  nodeUnzip,
-  unzipChunk,
-  unzipChunkSlice,
-} = require('../src/unzip')
+const { pakoUnzip, unzipChunk, unzipChunkSlice } = require('../src/unzip')
 
 describe('unzip', () => {
   it('can unzip bgzip-1.txt.gz', async () => {
     const testData = fs.readFileSync(require.resolve('./data/bgzip-1.txt.gz'))
     const fromPako = await pakoUnzip(testData)
-    const fromNode = await nodeUnzip(testData)
-    expect(fromNode).toEqual(fromPako)
-    expect(fromNode.length).toEqual(65569)
     expect(fromPako.length).toEqual(65569)
   })
 


### PR DESCRIPTION
Node 11 appears to have changed some ZLib things that broke bgzf processing

See https://travis-ci.com/github/GMOD/jbrowse-components/builds/171664475

This removes nodeUnzip as a result

