### PR TITLE
Fix browserify issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@babel/runtime": "^7.3.4",
     "es6-promisify": "^6.0.1",
-    "fs-extra": "^7.0.0",
     "long": "^4.0.0",
     "pako": "^1.0.10"
   },

--- a/src/localFile.js
+++ b/src/localFile.js
@@ -1,24 +1,31 @@
+const promisify = require('es6-promisify').promisify
 const fs =
   // eslint-disable-next-line camelcase
-  typeof __webpack_require__ !== 'function' ? require('fs-extra') : undefined
+  typeof __webpack_require__ !== 'function' ? require('fs') : undefined
+
+const fsOpen = fs && fs.open && promisify(fs.open)
+const fsRead = fs && fs.read && promisify(fs.read)
+const fsFStat = fs && fs.fstat && promisify(fs.fstat)
 
 // LocalFile is pretty much just an implementation of the node 10+ fs.promises filehandle,
 // we can switch to that when the API is stable
 class LocalFile {
   constructor(path) {
-    this.fdPromise = fs.open(path, 'r')
+    this.fdPromise = fsOpen(path, 'r')
     this.path = path
   }
 
   async read(buf, offset, length, position) {
     const fd = await this.fdPromise
-    const ret = await fs.read(fd, buf, offset, length, position)
-    return ret
+    const ret = await fsRead(fd, buf, offset, length, position)
+    return {
+      bytesRead: ret,
+    }
   }
 
   async stat() {
     const fd = await this.fdPromise
-    return fs.fstat(fd)
+    return fsFStat(fd)
   }
 }
 


### PR DESCRIPTION
This PR allows to use the package via browserify in a browser. It removes `fs-extra` dependency. This issue is similar to: https://github.com/GMOD/generic-filehandle/pull/79.

I am aware that LocalFile.read does not return all the data that before, but my understanding was that it is internal class that should not be used outside of the package. If that is not the case please let me know and I will try to fix it.

My ultimate goal with those two Pull Request is to make [tabix-js](https://github.com/GMOD/tabix-js) available via browserify.