### PR TITLE
Specify `nodeUnzip`'s return type

### DIFF
--- a/src/unzip.ts
+++ b/src/unzip.ts
@@ -5,7 +5,7 @@ import { pakoUnzip, unzipChunk, unzipChunkSlice } from './unzip-pako'
 const gunzip = promisify(zlib.gunzip)
 
 // in node, just use the native unzipping with Z_SYNC_FLUSH
-function nodeUnzip(input: Buffer) {
+function nodeUnzip(input: Buffer): Promise<Buffer> {
   //@ts-ignore
   return gunzip(input, {
     finishFlush: (zlib.constants || zlib).Z_SYNC_FLUSH,


### PR DESCRIPTION
This specifies that `nodeUnzip` returns `Promise<Buffer>`, since otherwise it thinks it's `Promise<unknown>`. I think that according to the [types for zlib](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8b31ef8f285911267318403ef7ab46096f806ce0/types/node/zlib.d.ts#L216) that `Promise<Buffer>` is accurate.