### PR TITLE
Remove safe checking for long integers by default

### DIFF
--- a/src/bgzFilehandle.ts
+++ b/src/bgzFilehandle.ts
@@ -84,7 +84,7 @@ export default class BgzFilehandle {
 
     // uncompress it
     const unzippedBuffer = await unzip(
-      blockBuffer.slice(0, blockCompressedLength),
+      blockBuffer.subarray(0, blockCompressedLength),
     )
 
     return unzippedBuffer as Buffer

--- a/src/gziIndex.ts
+++ b/src/gziIndex.ts
@@ -8,14 +8,18 @@ export default class GziIndex {
   filehandle: GenericFilehandle
 
   index?: any
+  safe: boolean
 
   constructor({
     filehandle,
     path,
+    safe = false,
   }: {
     filehandle?: GenericFilehandle
     path?: string
+    safe?: boolean
   }) {
+    this.safe = safe
     if (filehandle) {
       this.filehandle = filehandle
     } else if (path) {
@@ -29,8 +33,9 @@ export default class GziIndex {
     //@ts-ignore
     const long = Long.fromBytesLE(buf.slice(offset, offset + 8), unsigned)
     if (
-      long.greaterThan(Number.MAX_SAFE_INTEGER) ||
-      long.lessThan(Number.MIN_SAFE_INTEGER)
+      this.safe &&
+      (long.greaterThan(Number.MAX_SAFE_INTEGER) ||
+        long.lessThan(Number.MIN_SAFE_INTEGER))
     ) {
       throw new TypeError('integer overflow')
     }

--- a/src/gziIndex.ts
+++ b/src/gziIndex.ts
@@ -31,7 +31,7 @@ export default class GziIndex {
 
   _readLongWithOverflow(buf: Buffer, offset = 0, unsigned = true) {
     //@ts-ignore
-    const long = Long.fromBytesLE(buf.slice(offset, offset + 8), unsigned)
+    const long = Long.fromBytesLE(buf.subarray(offset, offset + 8), unsigned)
     if (
       this.safe &&
       (long.greaterThan(Number.MAX_SAFE_INTEGER) ||

--- a/src/unzip-pako.ts
+++ b/src/unzip-pako.ts
@@ -22,7 +22,7 @@ async function unzip(inputData: Buffer) {
     const chunks = []
     let inflator
     do {
-      const remainingInput = inputData.slice(pos)
+      const remainingInput = inputData.subarray(pos)
       inflator = new Inflate()
       //@ts-ignore
       ;({ strm } = inflator)
@@ -61,7 +61,7 @@ async function unzipChunk(inputData: Buffer) {
     const cpositions = []
     const dpositions = []
     do {
-      const remainingInput = inputData.slice(cpos)
+      const remainingInput = inputData.subarray(cpos)
       const inflator = new Inflate()
       // @ts-ignore
       ;({ strm } = inflator)
@@ -93,7 +93,7 @@ async function unzipChunk(inputData: Buffer) {
   }
 }
 
-// similar to unzipChunk above but slices (0,minv.dataPosition) and (maxv.dataPosition,end) off
+// similar to unzipChunk above but subarrays (0,minv.dataPosition) and (maxv.dataPosition,end) off
 async function unzipChunkSlice(inputData: Buffer, chunk: Chunk) {
   try {
     let strm
@@ -104,7 +104,7 @@ async function unzipChunkSlice(inputData: Buffer, chunk: Chunk) {
     const cpositions = []
     const dpositions = []
     do {
-      const remainingInput = inputData.slice(cpos - minv.blockPosition)
+      const remainingInput = inputData.subarray(cpos - minv.blockPosition)
       const inflator = new Inflate()
       // @ts-ignore
       ;({ strm } = inflator)
@@ -121,7 +121,9 @@ async function unzipChunkSlice(inputData: Buffer, chunk: Chunk) {
       dpositions.push(dpos)
       if (decompressedBlocks.length === 1 && minv.dataPosition) {
         // this is the first chunk, trim it
-        decompressedBlocks[0] = decompressedBlocks[0].slice(minv.dataPosition)
+        decompressedBlocks[0] = decompressedBlocks[0].subarray(
+          minv.dataPosition,
+        )
         len = decompressedBlocks[0].length
       }
       const origCpos = cpos
@@ -131,11 +133,11 @@ async function unzipChunkSlice(inputData: Buffer, chunk: Chunk) {
       if (origCpos >= maxv.blockPosition) {
         // this is the last chunk, trim it and stop decompressing
         // note if it is the same block is minv it subtracts that already
-        // trimmed part of the slice length
+        // trimmed part of the subarray length
 
         decompressedBlocks[decompressedBlocks.length - 1] = decompressedBlocks[
           decompressedBlocks.length - 1
-        ].slice(
+        ].subarray(
           0,
           maxv.blockPosition === minv.blockPosition
             ? maxv.dataPosition - minv.dataPosition + 1


### PR DESCRIPTION
Removes the checking for values of the Long, takes a measurable amount of time (100ms) in performance profiling, it may be ok to trust the data by default

Also replaces slice with subarray, Buffer.slice is a deprecated method https://nodejs.org/api/buffer.html#bufslicestart-end

